### PR TITLE
Implements simulator recipe start options (state/effects)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp
 .idea/
 *.iml
 Thumbs.db
+/.project

--- a/app/components/buffs.html
+++ b/app/components/buffs.html
@@ -1,6 +1,6 @@
 <div class="buffs well well-small">
   <div class="buff" ng-repeat="buff in buffs track by $index">
-    <div class="image-wrap glossy icon">
+    <div class="image-wrap glossy icon" data-ng-class="{'selectable' : actionable == true}" data-ng-click="execute(buff)">
       <img ng-src="{{getActionImagePath(buff.name, recipe.cls)}}"/>
     </div>
     <br/>

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -138,9 +138,8 @@ legend small > .light {
   display: inline-block;
 }
 
-.bonus-stats h5 {
-  margin-top: 0;
-}
+.bonus-stats h5 { margin: 0; }
+.bonus-stats th { margin-bottom: 5px; }
 
 .bonus-stats form {
   margin: 0;
@@ -153,6 +152,7 @@ legend small > .light {
 
 .bonus-stats td.value {
   text-align: right;
+  font-size: inherit !important;
 }
 
 .bonus-stats input {
@@ -183,11 +183,14 @@ legend small > .light {
 .simulator-status table {
   width: 100%;
   background: #f5f5f5;
-  border: 2px solid #e3e3e3;
-  border-radius: 10px;
+  border: 1px solid #e3e3e3;
+  border-radius: 3px;
   padding: 10px;
   border-collapse: separate;
 }
+
+.simulator-status h5 { margin: 0; }
+.simulator-status th { margin-bottom: 5px; }
 
 .simulator-status td {
 /*  background: #f00;*/
@@ -208,6 +211,17 @@ legend small > .light {
   width: 30%;
   text-align: right;
   font-size: larger;
+}
+.recipeStartWith td.operator {
+  width : 50px;
+  text-align: center;
+}
+.recipeStartWith td.value {
+  text-align: left !important;
+}
+.simulator-status td.value input{
+  margin: 0;
+  text-align: right;
 }
 
 div[content*="xivdb"] div.tooltip-inner {
@@ -475,6 +489,24 @@ div[content*="xivdb"] div.tooltip-arrow {
 .icon .cross-class>img {
   width: 16px;
 }
+
+.icon .more:hover, .icon .less:hover {
+  opacity: 0.4;
+  background-color: white;
+}
+.icon .more, .icon .less {
+  position: absolute;
+  left: 0;
+  font-size: 16px;
+  line-height: 16px;
+  color: white;
+  width: 100%;
+  height: 50%;
+  z-index: 2;
+  cursor: pointer;
+}
+.icon .less { bottom: 0; }
+.icon .more { top: 0; }
 
 .sequence-small .icon .cross-class>img {
   width: 12px;
@@ -810,3 +842,11 @@ legend + .control-group {
 .charimport-result td.number {
   text-align: right;
 }
+.margin-0 { margin : 0px !important; }
+.margin-top-10 { margin-top : 10px }
+td.min-width {width: 1px;}
+.flex {
+  display : flex;
+  align-items: center;
+}
+

--- a/app/index.html
+++ b/app/index.html
@@ -93,6 +93,7 @@
 <script src="js/controllers/solver.js"></script>
 <script src="js/controllers/sequenceeditor.js"></script>
 <script src="js/controllers/options.js"></script>
+<script src="js/controllers/recipeStartWith.js"></script>
 <script src="js/controllers/charimport.js"></script>
 <script src="js/directives.js"></script>
 <script src="js/filters.js"></script>
@@ -102,6 +103,7 @@
 <script src="js/components/action-sequence.js"></script>
 <script src="js/components/macros.js"></script>
 <script src="js/components/buffs.js"></script>
+<script src="js/ffxivcraftmodel.js"></script>
 
 </body>
 

--- a/app/js/components/buffs.js
+++ b/app/js/components/buffs.js
@@ -7,12 +7,13 @@ angular.module('ffxivCraftOptWeb.components')
       templateUrl: 'components/buffs.html',
       scope: {
         effects: '=',
-        recipe: '='
+        recipe: '=',
+        action : "&?"
       },
       controller: function ($scope, _getActionImagePath) {
         $scope.getActionImagePath = _getActionImagePath;
-        
-        var update = function () {
+
+          var update = function () {
           $scope.buffs = [];
 
 
@@ -27,9 +28,26 @@ angular.module('ffxivCraftOptWeb.components')
           }
         };
 
-        $scope.$watchCollection('effects', update);
+        $scope.$watchCollection('effects.countDowns', update);
+        $scope.$watchCollection('effects.countUps', update);
+
+        // Execute on click action
+        $scope.execute = function(buff){
+          if (angular.isFunction($scope.action))
+            $scope.action({buff: buff});
+        }
+
 
         update();
+      },
+
+      link: function (scope, element, attrs) {
+        // One-way method bindind bind a noop() function even if no attributes was set. So force value to be undefined if no callback was set
+        if (!attrs.action) {
+          scope.action = undefined;
+        }
+        scope.actionable = angular.isFunction(scope.action);
       }
+
     }
   });

--- a/app/js/components/simulator-status.js
+++ b/app/js/components/simulator-status.js
@@ -8,6 +8,7 @@ angular.module('ffxivCraftOptWeb.components')
       scope: {
         crafter: '=',
         bonusStats: '=',
+        recipeStartWith : "=startWith",
         recipe: '=',
         status: '=',
         valid: '&'
@@ -29,11 +30,11 @@ angular.module('ffxivCraftOptWeb.components')
             $scope.cp = $scope.status.state.cp;
           }
           else {
-            $scope.durability = $scope.recipe.durability;
-            $scope.condition = '';
-            $scope.progress = 0;
-            $scope.quality =  0;
-            $scope.cp = $scope.stats.cp;
+            $scope.durability = $scope.recipeStartWith.durability || $scope.recipe.durability;
+            $scope.condition = $scope.recipeStartWith.condition || '';
+            $scope.progress = $scope.recipeStartWith.difficulty || 0;
+            $scope.quality =  $scope.recipeStartWith.quality || 0;
+            $scope.cp = $scope.recipeStartWith.cp || $scope.stats.cp;
           }
 
           $scope.progressPercent = Math.min(100, $scope.progress / $scope.recipe.difficulty * 100);
@@ -47,6 +48,7 @@ angular.module('ffxivCraftOptWeb.components')
 
         $scope.$watchCollection("crafter", update);
         $scope.$watchCollection("bonusStats", update);
+        $scope.$watchCollection("recipeStartWith", update);
         $scope.$watchCollection("recipe", update);
         $scope.$watchCollection("status", update);
 

--- a/app/js/controllers/recipeStartWith.js
+++ b/app/js/controllers/recipeStartWith.js
@@ -1,0 +1,195 @@
+"use strict";
+
+angular.module('ffxivCraftOptWeb.controllers').controller('RecipeStartWithController', function ($scope, $modalInstance, _getActionImagePath, crafter, recipe, recipeStartWith, bonusStats) {
+
+  $scope.getActionImagePath = _getActionImagePath;
+  $scope.crafter = angular.copy(crafter);
+  $scope.bonusStats = angular.copy(bonusStats);
+  $scope.recipe = angular.copy(recipe);
+  $scope.recipeStartWith = angular.extend({}, recipeStartWith);
+  $scope.recipeStartWith.effects = angular.extend(new EffectTracker(), recipeStartWith.effects);
+  $scope._recipeStartWith = angular.extend({}, recipeStartWith);
+
+  $scope.tabs = {
+    state : false,
+    effects : true
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // Actions exclusions : whenever action is selected, remove all excluded actions from effects list
+  // Associate action to action list or name action pattern to exclude
+  var Exclusions = {
+    get : function(action){ return this[action.shortName] },
+    add : function(actions, excluded){
+      if (!angular || !excluded) return;
+
+      var self = this;
+      if (!angular.isArray(actions))
+        actions = [ actions ]
+      if (!angular.isArray(excluded))
+        excluded = [ excluded ]
+
+      actions.forEach(function(action){
+        self[action.shortName] = excluded;
+      });
+    }
+  };
+  Exclusions.add(AllActions.steadyHand, AllActions.steadyHand2);
+  Exclusions.add(AllActions.steadyHand2, AllActions.steadyHand);
+  Exclusions.add(AllActions.wasteNot, AllActions.wasteNot2);
+  Exclusions.add(AllActions.wasteNot2, AllActions.wasteNot);
+  Exclusions.add(AllActions.ingenuity, AllActions.ingenuity2);
+  Exclusions.add(AllActions.ingenuity2, AllActions.ingenuity);
+  Exclusions.add(AllActions.ingenuity2, AllActions.ingenuity);
+  Exclusions.add([
+    AllActions.nameOfEarth,
+    AllActions.nameOfFire,
+    AllActions.nameOfIce,
+    AllActions.nameOfLightning,
+    AllActions.nameOfWater,
+    AllActions.nameOfWind
+  ], "nameOf");
+
+  // ----------------------------------------------------------------------------------------------
+
+  /**
+   * Set effect list
+   * @type {Array}
+   */
+  $scope.crafterEffectActions = []
+  for (var i = 0; i < $scope.crafter.actions.length; i++) {
+    var action = AllActions[$scope.crafter.actions[i]];
+    if (action.type != "immediate")
+      $scope.crafterEffectActions.push(action);
+  }
+
+  /**
+   * Add effects action
+   * @param action
+   * @param order
+   */
+  $scope.makeEffect = function (action, order){
+    var effects = $scope.recipeStartWith.effects.countDowns;
+    var baseIndex = 1;
+
+    if (action.type == "countup") {
+      effects = $scope.recipeStartWith.effects.countUps;
+      baseIndex = 0;
+    }
+
+    // Get active turns value. Handle specifics (Marker's mark/InnerQuiet/etc..)
+    // --------------------------------------------
+    var activeTurns = action.activeTurns;
+    // Marker's mark, depend on recipe difficulty
+    if (isActionEq(action, AllActions.makersMark)) {
+      activeTurns = Math.ceil(recipe.difficulty / 100);
+      if (activeTurns == 0)
+        activeTurns = 1;
+    }
+    // Innerquiet, max is 11
+    if (isActionEq(action, AllActions.innerQuiet)) {
+      activeTurns = 11;
+    }
+
+    // First click : initialize effect
+    // --------------------------------------------
+    if (effects[action.shortName] == undefined){
+      // Remove exclusions first
+      applyExclusions(action);
+
+      effects[action.shortName] = (action.type == "countup" ? baseIndex : activeTurns);
+    }else{
+
+    // Change effect value (+/-)
+    // --------------------------------------------
+      var value = effects[action.shortName] + (order < 0 ? -1 : 1);
+      if (value > activeTurns + baseIndex - 1)
+        value = baseIndex;
+      if (value < baseIndex)
+        value = activeTurns + baseIndex - 1;
+
+      // Finally, set value
+      // --------------------------------------------
+      effects[action.shortName] = value;
+    }
+  }
+
+  /**
+   * Apply exclusions
+   * @param action
+   */
+  var applyExclusions = function(action){
+    var excludeList = Exclusions.get(action);
+    if (!angular.isArray(excludeList))
+      return;
+
+    excludeList.forEach(function(exclude){
+      if (angular.isObject(exclude))
+        $scope.removeEffect(exclude);
+
+      if (angular.isString(exclude)){
+        $scope.crafterEffectActions.forEach(function(action){
+          if (new RegExp(exclude).test(action.shortName))
+            $scope.removeEffect(action);
+        })
+      }
+    })
+  }
+
+  /**
+   * Remove effect from list
+   * @param e effect
+   */
+  $scope.removeEffect = function(e){
+    if (!e) return;
+    var actionName = e.shortName || e.name;
+    if (!actionName) return;
+
+    delete $scope.recipeStartWith.effects.countDowns[actionName];
+    delete $scope.recipeStartWith.effects.countUps[actionName];
+  }
+
+  /**
+   * Return true if nothing is set
+   * @returns {boolean}
+   */
+  $scope.isEmptyState = function(){
+    var startWith = $scope.recipeStartWith;
+
+    return startWith.durability === undefined
+        && startWith.difficulty === undefined
+        && startWith.quality === undefined
+        && startWith.cp === undefined
+        && startWith.condition === undefined
+        && Object.keys(startWith.effects.countUps).length == 0
+        && Object.keys(startWith.effects.countDowns).length == 0;
+  }
+
+  /**
+   * Indicate whether there is a user modification that can be reverted
+   * @returns {boolean}
+   */
+  $scope.canRevert = function(){
+    return angular.toJson($scope.recipeStartWith) != angular.toJson($scope._recipeStartWith);
+  }
+
+  $scope.save = function () {
+    $modalInstance.close({
+      recipeStartWith : $scope.recipeStartWith
+    });
+  };
+
+  $scope.cancel = function () {
+    $modalInstance.dismiss('cancel');
+  }
+
+  $scope.revert = function () {
+    $scope.recipeStartWith = angular.extend({}, $scope._recipeStartWith);
+  }
+
+  $scope.clear = function () {
+    $scope.recipeStartWith = {
+      effects : new EffectTracker()
+    }
+  }
+});

--- a/app/js/controllers/sequenceeditor.js
+++ b/app/js/controllers/sequenceeditor.js
@@ -14,13 +14,15 @@ angular.module('ffxivCraftOptWeb.controllers')
     $scope.editSequence = [];
     $scope.availableActions = [];
     $scope.recipe = {};
+    $scope.recipeStartWith = {};
 
 
-    $scope.$on('sequence.editor.init', function (event, origSequence, recipe, crafterStats, bonusStats, sequenceSettings) {
+    $scope.$on('sequence.editor.init', function (event, origSequence, recipe, crafterStats, bonusStats, sequenceSettings, recipeStartWith) {
       $scope.origSequence = origSequence;
       $scope.editSequence = angular.copy(origSequence);
       $scope.availableActions = crafterStats.actions;
       $scope.recipe = recipe;
+      $scope.recipeStartWith = recipeStartWith;
 
       $scope.unwatchSequence = $scope.$watchCollection('editSequence', function () {
         $scope.$emit('update.sequence', $scope.editSequence);
@@ -40,7 +42,7 @@ angular.module('ffxivCraftOptWeb.controllers')
 
     $scope.actionClasses = function (action, cls, index) {
       var wastedAction = $scope.simulatorStatus.state && (index + 1 > $scope.simulatorStatus.state.lastStep);
-      var cpExceeded = _actionsByName[action].cpCost > $scope.simulatorStatus.state.cp;
+      var cpExceeded = $scope.simulatorStatus.state && (_actionsByName[action].cpCost > $scope.simulatorStatus.state.cp);
       return {
         'faded-icon': !$scope.isActionSelected(action, cls),
         'wasted-action': wastedAction,

--- a/app/js/controllers/simulator.js
+++ b/app/js/controllers/simulator.js
@@ -1,5 +1,29 @@
 "use strict";
 
+// Remove Accent from source (ex: ï¿½ï¿½ï¿½ï¿½ï¿½ will be returned as ueeua).
+// Use to compare string without accents
+// ---------------------------------------------------
+String.prototype.removeAccent = function(){
+    var accent = [
+            /[\300-\306]/g, /[\340-\346]/g, // A, a
+            /[\310-\313]/g, /[\350-\353]/g, // E, e
+            /[\314-\317]/g, /[\354-\357]/g, // I, i
+            /[\322-\330]/g, /[\362-\370]/g, // O, o
+            /[\331-\334]/g, /[\371-\374]/g, // U, u
+            /[\321]/g, /[\361]/g, // N, n
+            /[\307]/g, /[\347]/g, // C, c
+        ],
+        noaccent = ['A','a','E','e','I','i','O','o','U','u','N','n','C','c'];
+
+    var str = this;
+    for (var i = 0; i < accent.length; i++){
+        str = str.replace(accent[i], noaccent[i]);
+    }
+
+    return str;
+};
+
+
 angular.module('ffxivCraftOptWeb.controllers').controller('SimulatorController', function ($scope, $filter, $modal,
   $rootScope, $translate, $timeout, $state, _recipeLibrary, _simulator, _actionsByName)
 {
@@ -39,7 +63,20 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SimulatorController',
     $scope.recipeSearch.loading = true;
     var p = _recipeLibrary.recipesForClass($translate.use(), $scope.recipe.cls);
     p.then(function (recipes) {
-      $scope.recipeSearch.list = $filter('filter')(recipes, {name: $scope.recipeSearch.text});
+        // Restrict recipes to crafter level
+        recipes  = $filter('filter')(recipes, {baseLevel: $scope.crafter.stats[$scope.recipe.cls].level}, function(recipeLevel, crafterLevel){
+            if (!crafterLevel || crafterLevel >= recipeLevel - 5)
+                return true;
+            return false;
+        });
+
+        // Then filter on text search
+        $scope.recipeSearch.list = $filter('filter')(recipes, {name: $scope.recipeSearch.text}, function(recipeName, recipeSearch){
+          if (recipeName == undefined || recipeSearch == undefined)
+            return true;
+
+          return recipeName.removeAccent().toUpperCase().indexOf(recipeSearch.removeAccent().toUpperCase()) >= 0;
+      });
       $scope.recipeSearch.selected = Math.min($scope.recipeSearch.selected, $scope.recipeSearch.list.length - 1);
       $scope.recipeSearch.loading = false;
     }, function (err) {
@@ -68,7 +105,7 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SimulatorController',
     p.then(function (recipe) {
       recipe = angular.copy(recipe);
       recipe.cls = cls;
-      recipe.startQuality = 0;
+      recipe.recipeStartWith = null;
       $scope.$emit('recipe.selected', recipe);
     }, function (err) {
       console.error("Failed to load recipe:", err);
@@ -116,6 +153,9 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SimulatorController',
     if ($scope.sequence.length > 0 && $scope.isValidSequence($scope.sequence, $scope.recipe.cls)) {
       $scope.runMonteCarloSim();
     }
+    else if ($scope.sequence.length < 1 && $scope.recipeStartWith.effects) {
+      $scope.runMonteCarloSim();
+    }
     else {
       $scope.simulatorStatus.sequence = null;
       $scope.simulatorStatus.monteCarlo.logText = '';
@@ -146,7 +186,7 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SimulatorController',
   $scope.runMonteCarloSim = function () {
     var settings = {
       crafter: addCrafterBonusStats($scope.crafter.stats[$scope.recipe.cls], $scope.bonusStats),
-      recipe: addRecipeBonusStats($scope.recipe, $scope.bonusStats),
+      recipe: setRecipeSartWith($scope.recipe, $scope.recipeStartWith),
       sequence: $scope.sequence,
       maxTricksUses: $scope.sequenceSettings.maxTricksUses,
       maxMontecarloRuns: $scope.sequenceSettings.maxMontecarloRuns,
@@ -178,7 +218,7 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SimulatorController',
   $scope.runProbabilisticSim = function () {
     var settings = {
       crafter: addCrafterBonusStats($scope.crafter.stats[$scope.recipe.cls], $scope.bonusStats),
-      recipe: addRecipeBonusStats($scope.recipe, $scope.bonusStats),
+      recipe: setRecipeSartWith($scope.recipe, $scope.recipeStartWith),
       sequence: $scope.sequence,
       maxTricksUses: $scope.sequenceSettings.maxTricksUses,
       maxMontecarloRuns: $scope.sequenceSettings.maxMontecarloRuns,
@@ -215,7 +255,7 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SimulatorController',
   $scope.editSequenceInline = function () {
     $scope.editingSequence = true;
     $timeout(function () {
-      $scope.$broadcast('sequence.editor.init', $scope.sequence,  $scope.recipe, $scope.crafter.stats[$scope.recipe.cls], $scope.bonusStats, $scope.sequenceSettings);
+      $scope.$broadcast('sequence.editor.init', $scope.sequence,  $scope.recipe, $scope.crafter.stats[$scope.recipe.cls], $scope.bonusStats, $scope.sequenceSettings, $scope.recipeStartWith);
     });
   };
 

--- a/app/js/controllers/solver.js
+++ b/app/js/controllers/solver.js
@@ -48,7 +48,7 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SolverController', fu
   function runProbabilisticSim(sequence) {
     var settings = {
       crafter: addCrafterBonusStats($scope.crafter.stats[$scope.recipe.cls], $scope.bonusStats),
-      recipe: addRecipeBonusStats($scope.recipe, $scope.bonusStats),
+      recipe: setRecipeSartWith($scope.recipe, $scope.recipeStartWith),
       sequence: sequence,
       maxTricksUses: $scope.sequenceSettings.maxTricksUses,
       maxMontecarloRuns: $scope.sequenceSettings.maxMontecarloRuns,
@@ -78,7 +78,7 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SolverController', fu
   $scope.runMonteCarloSim = function (sequence) {
     var settings = {
       crafter: addCrafterBonusStats($scope.crafter.stats[$scope.recipe.cls], $scope.bonusStats),
-      recipe: addRecipeBonusStats($scope.recipe, $scope.bonusStats),
+      recipe: setRecipeSartWith($scope.recipe, $scope.recipeStartWith),
       sequence: sequence,
       maxTricksUses: $scope.sequenceSettings.maxTricksUses,
       maxMontecarloRuns: $scope.sequenceSettings.maxMontecarloRuns,
@@ -127,7 +127,7 @@ angular.module('ffxivCraftOptWeb.controllers').controller('SolverController', fu
 
     var settings = {
       crafter: addCrafterBonusStats($scope.crafter.stats[$scope.recipe.cls], $scope.bonusStats),
-      recipe: addRecipeBonusStats($scope.recipe, $scope.bonusStats),
+      recipe: setRecipeSartWith($scope.recipe, $scope.recipeStartWith),
       sequence: sequence,
       algorithm: $scope.solver.algorithm,
       maxTricksUses: $scope.sequenceSettings.maxTricksUses,

--- a/app/js/ffxivcraftmodel.js
+++ b/app/js/ffxivcraftmodel.js
@@ -50,11 +50,11 @@ function Crafter(cls, level, craftsmanship, control, craftPoints, actions) {
     }
 }
 
-function Recipe(level, difficulty, durability, startQuality, maxQuality, aspect) {
+function Recipe(level, difficulty, durability, recipeStartWith, maxQuality, aspect) {
     this.level = level;
     this.difficulty = difficulty;
     this.durability = durability;
-    this.startQuality = startQuality;
+    this.recipeStartWith = recipeStartWith;
     this.maxQuality = maxQuality;
     this.aspect = aspect;
 }
@@ -281,7 +281,7 @@ function NewStateFromSynth(synth) {
     var lastStep = 0;
     var durabilityState = synth.recipe.durability;
     var cpState = synth.crafter.craftPoints;
-    var qualityState = synth.recipe.startQuality;
+    var qualityState = 0;
     var progressState = 0;
     var wastedActions = 0;
     var trickUses = 0;
@@ -290,6 +290,45 @@ function NewStateFromSynth(synth) {
     var crossClassActionList = {};
     var effects = new EffectTracker();
     var condition = 'Normal';
+
+    if (synth.recipe.recipeStartWith){
+        if (synth.recipe.recipeStartWith.durability) {
+            durabilityState = synth.recipe.recipeStartWith.durability;
+            step = 1;
+        }
+
+        if (synth.recipe.recipeStartWith.difficulty){
+            progressState = synth.recipe.recipeStartWith.difficulty;
+            step = 1;
+        }
+
+        if (synth.recipe.recipeStartWith.quality){
+            qualityState = synth.recipe.recipeStartWith.quality;
+            step = 1;
+        }
+
+        if (synth.recipe.recipeStartWith.cp){
+            cpState = synth.recipe.recipeStartWith.cp;
+            step = 1;
+        }
+
+        if (synth.recipe.recipeStartWith.condition){
+            condition = synth.recipe.recipeStartWith.condition;
+            step = 1;
+        }
+
+        if (synth.recipe.recipeStartWith.effects){
+            effects = synth.recipe.recipeStartWith.effects;
+            step = 1;
+
+            // Set nameOfElementUses
+            if (effects.countDowns)
+                for (var effect in effects.countDowns) {
+                    if (effect.indexOf('nameOf') >= 0)
+                        nameOfElementUses++;
+                }
+        }
+    }
 
     return new State(synth, step, lastStep, '', durabilityState, cpState, qualityState, progressState, wastedActions, trickUses, nameOfElementUses, reliability, crossClassActionList, effects, condition);
 }

--- a/app/js/filters.js
+++ b/app/js/filters.js
@@ -11,4 +11,5 @@ angular.module('ffxivCraftOptWeb.filters', [])
       }
       return output;
     }
-  });
+  })
+;

--- a/app/js/services/simulator.js
+++ b/app/js/services/simulator.js
@@ -36,14 +36,10 @@ var SimulationService = function($timeout) {
 SimulationService.$inject = ['$timeout'];
 
 SimulationService.prototype.runMonteCarloSim = function(settings, success, error) {
-  if (settings.sequence.length <= 0) {
+  /*if (settings.sequence.length <= 0) {
     error({log: '', error: 'empty sequence'});
     return;
-  }
-  if (settings.recipe.startQuality === undefined) {
-    settings.recipe = angular.copy(settings.recipe);
-    settings.recipe.startQuality = 0;
-  }
+  }*/
 
   var id = this.nextId();
 
@@ -63,10 +59,6 @@ SimulationService.prototype.runProbabilisticSim = function (settings, success, e
   if (settings.sequence.length <= 0) {
     error({log: '', error: 'empty sequence'});
     return;
-  }
-  if (settings.recipe.startQuality === undefined) {
-    settings.recipe = angular.copy(settings.recipe);
-    settings.recipe.startQuality = 0;
   }
 
   var id = this.nextId();

--- a/app/js/simulationworker.js
+++ b/app/js/simulationworker.js
@@ -48,7 +48,7 @@ function setupSim(settings) {
   var recipe = new Recipe(settings.recipe.level,
     settings.recipe.difficulty,
     settings.recipe.durability,
-    settings.recipe.startQuality,
+    settings.recipe.recipeStartWith,
     settings.recipe.maxQuality,
     settings.recipe.aspect);
   var synth = new Synth(crafter, recipe, settings.maxTricksUses, settings.reliabilityPercent / 100.0,

--- a/app/js/solver/service.js
+++ b/app/js/solver/service.js
@@ -42,9 +42,8 @@ var SolverService = function($timeout) {
 SolverService.$inject = ['$timeout'];
 
 SolverService.prototype.start = function(settings, progress, success, error) {
-  if (settings.recipe.startQuality === undefined) {
+  if (settings.recipe.recipeStartWith === undefined) {
     settings.recipe = angular.copy(settings.recipe);
-    settings.recipe.startQuality = 0;
   }
 
   this.stopRequested = false;

--- a/app/js/solver/worker.js
+++ b/app/js/solver/worker.js
@@ -95,7 +95,7 @@ function start(settings) {
   var recipe = new Recipe(settings.recipe.level,
                           settings.recipe.difficulty,
                           settings.recipe.durability,
-                          settings.recipe.startQuality,
+                          settings.recipe.recipeStartWith,
                           settings.recipe.maxQuality,
                           settings.recipe.aspect);
   var synth = new Synth(crafter, recipe, settings.maxTricksUses, settings.reliabilityPercent/100.0, settings.useConditions);

--- a/app/modals/recipeStartWith.html
+++ b/app/modals/recipeStartWith.html
@@ -1,0 +1,96 @@
+<div class="modal-header">
+  <h3>State properties</h3>
+</div>
+
+<div class="modal-body" isolate-scrolling>
+  <form name="RecipeEffectsForm">
+
+      <div class="row-fluid">
+          <tabset>
+              <tab active="tabs.state">
+                  <tab-heading>State</i></tab-heading>
+                  <div class="span2"></div>
+                  <div class="span8">
+                      <div class="simulator-status recipeStartWith">
+                          <table>
+                              <tbody>
+                              <tr>
+                                  <td>Durability</td>
+                                  <td class="operator">=</td>
+                                  <td class="value">
+                                      <input class="input-mini" type="number" min="0" force-numeric placeholder="{{recipe.durability}}" ng-model="recipeStartWith.durability" max="{{recipe.durability}}" step="5"/>
+                                  </td>
+                                  <td class="min-width">&nbsp;/&nbsp;</td>
+                                  <td class="min-width text-right">{{recipe.durability}}</td>
+                              </tr>
+                              <tr>
+                                  <td>Progress</td>
+                                  <td class="operator">=</td>
+                                  <td class="value">
+                                      <input class="input-mini" type="number" min="0" force-numeric placeholder="0" ng-model="recipeStartWith.difficulty" max="{{recipe.difficulty}}" step="1"/>
+                                  </td>
+                                  <td>&nbsp;/&nbsp;</td>
+                                  <td class="text-right">{{recipe.difficulty}}</td>
+                              </tr>
+                              <tr>
+                                  <td>Quality</td>
+                                  <td class="operator">=</td>
+                                  <td class="value">
+                                      <input class="input-mini" type="number" min="0" force-numeric placeholder="0" ng-model="recipeStartWith.quality" max="{{recipe.maxQuality}}" step="1"/>
+                                  </td>
+                                  <td>&nbsp;/&nbsp;</td>
+                                  <td class="text-right">{{recipe.maxQuality}}</td>
+                              </tr>
+                              <tr>
+                                  <td>CP</td>
+                                  <td class="operator">=</td>
+                                  <td class="value">
+                                      <input class="input-mini" type="number" min="0" force-numeric placeholder="{{crafter.cp + bonusStats.cp}}" ng-model="recipeStartWith.cp" max="{{crafter.cp + bonusStats.cp}}" step="1"/>
+                                  </td>
+                                  <td>&nbsp;/&nbsp;</td>
+                                  <td class="text-right">{{crafter.cp + bonusStats.cp}}</td>
+                              </tr>
+                              <tr>
+                                  <td>Condition</td>
+                                  <td class="operator">=</td>
+                                  <td class="" colspan="3">
+                                      <select class="input-medium" name="algorithm" ng-model="recipeStartWith.condition" required>
+                                          <option>Normal</option>
+                                          <option>Good</option>
+                                          <option>Excellent</option>
+                                          <option>Poor</option>
+                                      </select>
+                                  </td>
+                              </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+                  <div class="span2"></div>
+              </tab>
+              <tab active="tabs.effects">
+                  <tab-heading>Effects</tab-heading>
+                  <div class="row-fluid">
+                      <buffs effects="recipeStartWith.effects" recipe="recipe" action="removeEffect(buff)"></buffs>
+                  </div>
+
+                  <div class="row-fluid">
+                      <div class="image-wrap glossy icon spinner" data-ng-repeat="action in crafterEffectActions">
+                          <img ng-src="{{getActionImagePath(action.shortName, recipe.cls)}}"/>
+                          <span class="more" data-ng-click="makeEffect(action, 1)"></span>
+                          <span class="less" data-ng-click="makeEffect(action, -1)"></span>
+                      </div>
+                  </div>
+              </tab>
+          </tabset>
+      </div>
+
+  </form>
+</div>
+
+<div class="modal-footer">
+    <button class="btn" ng-click="cancel()">Cancel</button>
+    <button class="btn btn-primary" ng-click="save()">Save</button>
+    <button class="btn btn-warning" ng-disabled="!canRevert()" ng-click="revert()">Revert</button>
+    <button class="btn btn-warning" ng-disabled="isEmptyState()" ng-click="clear()">Clear</button>
+</div>

--- a/app/views/simulator.html
+++ b/app/views/simulator.html
@@ -48,20 +48,75 @@
     </div>
     <div class="row-fluid">
       <div class="span8">
-        <simulator-status class="initial-guess" crafter="crafter.stats[recipe.cls]" bonus-stats="bonusStats" recipe="recipe" status="simulatorStatus"
+        <simulator-status class="initial-guess" crafter="crafter.stats[recipe.cls]" bonus-stats="bonusStats" start-with="recipeStartWith" recipe="recipe" status="simulatorStatus"
                           valid="isValidSequence(simulatorStatus.sequence, recipe.cls)"></simulator-status>
       </div>
-      <div class="span4">
-        <div class="bonus-stats">
-          <div class="well well-small">
-            <h5>L{{crafter.stats[recipe.cls].level}} {{recipe.cls}} Attributes <a ui-sref="crafter-attributes"><i class="fa fa-edit"></i></a></h5>
-            <form name="bonusStatsForm">
-              <table>
+
+      <!-- Starting with -->
+      <div class="span2">
+        <div class="simulator-status">
+          <form name="recipeStartWithForm">
+            <table>
+              <thead>
+                <th colspan="4" class="text-left"><h5>Start with&nbsp;<a href data-ng-click="showRecipeStartWithModal()"><i class="fa fa-edit"></i></a></h5></th>
+              </thead>
+              <tbody>
+              <tr>
+                <td>Durability</td>
+                <td>=</td>
+                <td class="value">
+                  <input class="input-mini" type="number" min="0" force-numeric placeholder="{{recipe.durability}}" ng-model="recipeStartWith.durability" max="{{recipe.durability}}" step="5"/>
+                </td>
+                <td class="min-width">&nbsp;/&nbsp;</td>
+                <td class="min-width text-right">{{recipe.durability}}</td>
+              </tr>
+              <tr>
+                <td>Progress</td>
+                <td>=</td>
+                <td class="value">
+                  <input class="input-mini" type="number" min="0" force-numeric placeholder="0" ng-model="recipeStartWith.difficulty" max="{{recipe.difficulty}}" step="1"/>
+                </td>
+                <td>&nbsp;/&nbsp;</td>
+                <td class="text-right">{{recipe.difficulty}}</td>
+              </tr>
+              <tr>
+                <td>Quality</td>
+                <td>=</td>
+                <td class="value">
+                  <input class="input-mini" type="number" min="0" force-numeric placeholder="0" ng-model="recipeStartWith.quality" max="{{recipe.maxQuality}}" step="1"/>
+                </td>
+                <td>&nbsp;/&nbsp;</td>
+                <td class="text-right">{{recipe.maxQuality}}</td>
+              </tr>
+              <tr>
+                <td>CP</td>
+                <td>=</td>
+                <td class="value">
+                  <input class="input-mini" type="number" min="0" force-numeric placeholder="{{crafter.stats[recipe.cls].cp + bonusStats.cp}}" ng-model="recipeStartWith.cp" max="{{crafter.stats[recipe.cls].cp + bonusStats.cp}}" step="1"/>
+                </td>
+                <td>&nbsp;/&nbsp;</td>
+                <td class="text-right">{{crafter.stats[recipe.cls].cp + bonusStats.cp}}</td>
+              </tr>
+              </tbody>
+            </table>
+          </form>
+        </div>
+      </div>
+
+      <!-- Crafter bonus stats -->
+      <div class="span2">
+        <div class="simulator-status bonus-stats">
+          <form name="bonusStatsForm">
+            <table>
+              <thead>
+                <th colspan="4" class="text-left"><h5>L{{crafter.stats[recipe.cls].level}} {{recipe.cls}} Attributes&nbsp;<a ui-sref="crafter-attributes"><i class="fa fa-edit"></i></a></h5></th>
+              </thead>
+              <tbody>
                 <tr>
                   <td>Craftsmanship</td>
                   <td class="value">{{crafter.stats[recipe.cls].craftsmanship}}</td>
                   <td>+</td>
-                  <td>
+                  <td class="value">
                     <input class="input-mini" type="number" min="0" required force-numeric ng-model="bonusStats.craftsmanship"/>
                   </td>
                 </tr>
@@ -69,7 +124,7 @@
                   <td>Control</td>
                   <td class="value">{{crafter.stats[recipe.cls].control}}</td>
                   <td>+</td>
-                  <td>
+                  <td class="value">
                     <input class="input-mini" type="number" min="0" required force-numeric ng-model="bonusStats.control"/>
                   </td>
                 </tr>
@@ -77,27 +132,23 @@
                   <td>CP</td>
                   <td class="value">{{crafter.stats[recipe.cls].cp}}</td>
                   <td>+</td>
-                  <td>
+                  <td class="value">
                     <input class="input-mini" type="number" min="0" required force-numeric ng-model="bonusStats.cp"/>
                   </td>
                 </tr>
                 <tr>
-                  <td>Start Quality</td>
-                  <td class="value"></td>
-                  <td>+</td>
-                  <td>
-                    <input class="input-mini" type="number" min="0" required force-numeric ng-model="bonusStats.startQuality"/>
-                  </td>
+                  <td colspan="4">&nbsp;</td>
                 </tr>
-              </table>
+              </tbody>
+            </table>
             </form>
-          </div>
         </div>
       </div>
+
     </div>
   </div>
 
-  <div class="row-fluid">
+  <div class="row-fluid margin-top-10">
     <div class="span12">
       <div class="row-fluid">
         <div ng-class="{'edit-mode': editingSequence}" ng-show="editingSequence">

--- a/app/views/solver.html
+++ b/app/views/solver.html
@@ -10,7 +10,7 @@
     </button>
     <button class="btn" ng-click="showOptionsModal()">Options...</button>
   </div>
-  <simulator-status class="solver-status" crafter="crafter.stats[recipe.cls]" bonus-stats="bonusStats" recipe="recipe" status="pageState.solverStatus" valid="isValidSequence(pageState.solverStatus.sequence, recipe.cls)"></simulator-status>
+  <simulator-status class="solver-status" crafter="crafter.stats[recipe.cls]" bonus-stats="bonusStats" start-with="recipeStartWith" recipe="recipe" status="pageState.solverStatus" valid="isValidSequence(pageState.solverStatus.sequence, recipe.cls)"></simulator-status>
   <h5>Initial Guess</h5>
   <action-sequence class="sequence-small" cls="recipe.cls" actions="sequence" action-classes="seqeunceActionClasses" tooltip-placement="right"></action-sequence>
   <div ng-show="pageState.solverStatus.running">


### PR DESCRIPTION
This functionnality aims to use the simulator/solver to finish a already ingame started craft.

Actually, when using the simulation/solver, it takes the recipe, crafter attributes and crafter bonus (given by foods usualy). Then, solver will try to find the best simulation. This is just a awesome feature, but it has limitations since this is assuming that simulation starts from the begining of the craft, and the use for hard recipe is currently limited.

So, from simulator windows, we still can set bonus crafter given by foods. Plus, we can set durability/progress/quality/cp. For conditions & effects, we can open modal window and set values.

In addition of that, i have limited recipe combo list to crafter level. If i'm lvl26, it don't want to see lvl50 recipes since i can"t make it.

Feel free, to give back you're comments ;) Or if you don't want to integrate this, it will not be a problem ^^

Thanks anyway for this tool.