### PR TITLE
Remove current class check from isActionCrossClass.

### DIFF
--- a/app/js/components/action-sequence.js
+++ b/app/js/components/action-sequence.js
@@ -26,7 +26,7 @@
     $scope.getActionImagePath = _getActionImagePath;
     $scope.cssClassesForAction = cssClassesForAction;
     $scope.actionForName = actionForName;
-    $scope.isActionCrossClass = isActionCrossClass;
+    $scope.isActionCrossClass = _isActionCrossClass;
 
     $scope.actionTooltips = {};
 
@@ -62,10 +62,6 @@
 
     function actionForName(name) {
       return _actionsByName[name];
-    }
-
-    function isActionCrossClass(name) {
-      return _isActionCrossClass(name, $scope.cls);
     }
   }
 })();

--- a/app/js/components/action-table.js
+++ b/app/js/components/action-table.js
@@ -26,7 +26,7 @@
     $scope.getActionImagePath = _getActionImagePath;
     $scope.cssClassesForAction = cssClassesForAction;
     $scope.actionForName = actionForName;
-    $scope.isActionCrossClass = isActionCrossClass;
+    $scope.isActionCrossClass = _isActionCrossClass;
 
     $scope.actionTooltips = {};
 
@@ -62,8 +62,5 @@
       return _actionsByName[name];
     }
 
-    function isActionCrossClass(name) {
-      return _isActionCrossClass(name, $scope.cls);
-    }
   }
 })();

--- a/app/js/components/macros.js
+++ b/app/js/components/macros.js
@@ -65,7 +65,7 @@
       var crossClass = {};
       for (var i = 0; i < sequence.length; i++) {
         var action = sequence[i];
-        if (_isActionCrossClass(action, cls) && !crossClass[action]) {
+        if (_isActionCrossClass(action) && !crossClass[action]) {
           crossClass[action] = true;
         }
       }

--- a/app/js/services/actions.js
+++ b/app/js/services/actions.js
@@ -243,7 +243,7 @@
     return info.imagePaths[cls];
   }
 
-  function isActionCrossClass(name, currentClass) {
+  function isActionCrossClass(name) {
     if (!angular.isDefined(name)) {
       console.error('undefined action');
       return undefined;
@@ -253,7 +253,7 @@
       console.error('unknown action: %s', name);
       return undefined;
     }
-    return info.cls !== 'All' && info.cls !== currentClass;
+    return info.cls !== 'All';
   }
 
 

--- a/app/views/simulator.html
+++ b/app/views/simulator.html
@@ -67,7 +67,7 @@
                     on-drop="dropAction(dragEl, dropEl)">
                 <img ng-src="{{getActionImagePath(action, recipe.cls)}}"/>
                 <span ng-if="actionForName(action).cpCost" class="cp">{{actionForName(action).cpCost}}</span>
-                <span ng-if="isActionCrossClass(action, cls)" class="cross-class">
+                <span ng-if="isActionCrossClass(action)" class="cross-class">
                   <img ng-src="img/classes/{{actionForName(action).cls}}.png"/>
                 </span>
               </div>


### PR DESCRIPTION
This causes cross-class actions for the current class to be added to the
 cross-class setup macro and show their class icon always.

@Ermad Could you check this out to see if it makes sense?