### PR TITLE
Use HW progress formula for crafters level 51-60 (fixes #222 and #227)

### DIFF
--- a/app/js/ffxivcraftmodel.js
+++ b/app/js/ffxivcraftmodel.js
@@ -75,8 +75,11 @@ Synth.prototype.calculateBaseProgressIncrease = function (levelDifference, craft
     var levelCorrectedProgress = 0;
     var recipeLevelPenalty = 0;
 
-    if (crafterLevel > 110) {
+    if (crafterLevel > 250) {
         baseProgress = 1.834712812e-5 * craftsmanship * craftsmanship + 1.904074773e-1 * craftsmanship + 1.544103837;
+    }
+    else if (crafterLevel > 110) {
+        baseProgress = 2.09860e-5 * craftsmanship * craftsmanship + 0.196184 * craftsmanship + 2.68452;
     }
     else {
         baseProgress = 0.214959 * craftsmanship + 1.6;


### PR DESCRIPTION
Reverts base progress formula for HW level crafters to previous values.