### PR TITLE
Add option to include macro lock command.

### DIFF
--- a/app/components/macros.html
+++ b/app/components/macros.html
@@ -5,10 +5,14 @@
       <label class="checkbox">
         <input type="checkbox" ng-model="options.setupCrossClassActions"/>{{ 'MACRO_CROSS_CLASS' | translate }}
       </label>
-      <br/>
+      <br ng-if="options.setupCrossClassActions"/>
       <label class="checkbox" ng-if="options.setupCrossClassActions">
         <input type="checkbox" ng-model="options.includeCurrentClassActions"/>
         {{ 'MACRO_INCLUDE_CLASS' | translate }}
+      </label>
+      <br/>
+      <label class="checkbox">
+        <input type="checkbox" ng-model="options.includeMacroLock"/>{{ 'MACRO_INCLUDE_LOCK' | translate }}
       </label>
     </div>
   </div>

--- a/app/js/components/macros.js
+++ b/app/js/components/macros.js
@@ -90,7 +90,7 @@
           lines.push(line);
         }
         else {
-          lines.push('/echo Error: Unknown action ' + action);
+          lines.push('/echo Error: Unknown action ' + action + '\n');
         }
       }
 
@@ -122,7 +122,6 @@
             line += waitString;
             time = options.waitTime
           }
-          line += '\n';
           lines.push({text: line, time: time});
         }
         else {
@@ -141,9 +140,14 @@
       var macroTime = 0;
       var macroIndex = 1;
 
+      if (options.includeMacroLock) {
+        macroString += '/macrolock\n';
+          macroLineCount++;
+      }
+
       for (var j = 0; j < lines.length; j++) {
         var line = lines[j];
-        macroString += line.text;
+        macroString += line.text + '\n';
         macroTime += line.time;
         macroLineCount += 1;
 
@@ -151,10 +155,16 @@
           if (lines.length - (j + 1) > 1) {
             macroString += '/echo Macro #' + macroIndex + ' complete ' + soundEffect(options.stepSoundEffect) + '\n';
             macroList.push({text: macroString, time: macroTime});
+
             macroString = '';
             macroLineCount = 0;
             macroTime = 0;
             macroIndex += 1;
+
+            if (options.includeMacroLock) {
+              macroString += '/macrolock\n';
+              macroLineCount++;
+            }
           }
         }
       }

--- a/app/locale/cn.json
+++ b/app/locale/cn.json
@@ -153,6 +153,7 @@
   "MACRO_CROSS_CLASS": "Generate cross-class action activation macro",
   "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
   "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
+  "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
 
   "INITIAL_GUESS": "Initial Guess",
   "WORKING_IN_PROGRESS": "Working...",
@@ -212,6 +213,7 @@
   "FINISH_SOUND_INFO": "Sound effect to play at the end of the last macro.,",
   "CROSS_CLASS_INFO": "Whether to generate a separate macro that activates the necessary cross-class actions.",
   "CURRENT_CLASS_INFO": "Whether to include the current class' actions in the cross-class action activation macro.",
+  "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
   "SPECIFY_SEED": "Specify Seed",
   "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
   "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",

--- a/app/locale/de.json
+++ b/app/locale/de.json
@@ -154,6 +154,7 @@
   "MACRO_CROSS_CLASS": "Generate cross-class action activation macro",
   "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
   "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
+  "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
 
   "INITIAL_GUESS": "Initial Guess",
   "WORKING_IN_PROGRESS": "Working...",
@@ -213,6 +214,7 @@
   "FINISH_SOUND_INFO": "Sound effect to play at the end of the last macro.,",
   "CROSS_CLASS_INFO": "Whether to generate a separate macro that activates the necessary cross-class actions.",
   "CURRENT_CLASS_INFO": "Whether to include the current class' actions in the cross-class action activation macro.",
+  "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
   "SPECIFY_SEED": "Specify Seed",
   "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
   "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",

--- a/app/locale/en.json
+++ b/app/locale/en.json
@@ -56,6 +56,7 @@
   "MACRO_CROSS_CLASS": "Generate cross-class action activation macro",
   "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
   "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
+  "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
 
   "INITIAL_GUESS": "Initial Guess",
   "WORKING_IN_PROGRESS": "Working...",
@@ -115,6 +116,7 @@
   "FINISH_SOUND_INFO": "Sound effect to play at the end of the last macro.,",
   "CROSS_CLASS_INFO": "Whether to generate a separate macro that activates the necessary cross-class actions.",
   "CURRENT_CLASS_INFO": "Whether to include the current class' actions in the cross-class action activation macro.",
+  "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
   "SPECIFY_SEED": "Specify Seed",
   "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
   "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",

--- a/app/locale/fr.json
+++ b/app/locale/fr.json
@@ -153,6 +153,7 @@
   "MACRO_CROSS_CLASS": "Générer les actions cross-class nécessaires à la macro",
   "MACRO_CROSS_ACTION_SETUP": "Macro setup des actions cross-class",
   "MACRO_INCLUDE_CLASS": "Inclure les cross-actions de la classe actuelle dans la génération",
+  "MACRO_INCLUDE_LOCK": "Inclure le verrou de macro au début de chaque macro",
 
   "INITIAL_GUESS": "Départ renseigné",
   "WORKING_IN_PROGRESS": "Calcul en cours...",
@@ -212,6 +213,7 @@
   "FINISH_SOUND_INFO": "Effet sonore joué à la fin de la dernière macro.",
   "CROSS_CLASS_INFO": "Indique si il faut générer une macro séparée qui active les différentes actions cross-class nécessaires.",
   "CURRENT_CLASS_INFO": "Indique si il faut inclure les actions de la classe actuelle dans la génération de la macro d'activation des actions cross-class.",
+  "MACRO_LOCK_INFO": "Indique s'il faut inclure une commande de verrouillage de macro au début de chaque macro.",
   "SPECIFY_SEED": "Nombre spécifique",
   "SEED_INFO": "Insérer une valeur spécifique pour reproduire les conditions similaires dans les simulations Monte Carlo.",
   "SPECIFY_SEED_INFO": "Permet de modifier la valeur de base aléatoire utilisée dans les simulations Monte Carlo.",

--- a/app/locale/ja.json
+++ b/app/locale/ja.json
@@ -153,6 +153,7 @@
   "MACRO_CROSS_CLASS": "Generate cross-class action activation macro",
   "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
   "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
+  "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
 
   "INITIAL_GUESS": "Initial Guess",
   "WORKING_IN_PROGRESS": "Working...",
@@ -212,6 +213,7 @@
   "FINISH_SOUND_INFO": "Sound effect to play at the end of the last macro.,",
   "CROSS_CLASS_INFO": "Whether to generate a separate macro that activates the necessary cross-class actions.",
   "CURRENT_CLASS_INFO": "Whether to include the current class' actions in the cross-class action activation macro.",
+  "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
   "SPECIFY_SEED": "Specify Seed",
   "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
   "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",

--- a/app/locale/ko.json
+++ b/app/locale/ko.json
@@ -153,6 +153,7 @@
   "MACRO_CROSS_CLASS": "Generate cross-class action activation macro",
   "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
   "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
+  "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
 
   "INITIAL_GUESS": "Initial Guess",
   "WORKING_IN_PROGRESS": "Working...",
@@ -214,6 +215,7 @@
   "CURRENT_CLASS_INFO": "Whether to include the current class' actions in the cross-class action activation macro.",
   "SPECIFY_SEED": "Specify Seed",
   "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
+  "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
   "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",
   "DEBUG": "Debug",
   "DEBUG_INFO": "Enable extra information in the simulator and solver logs.",

--- a/app/modals/options.html
+++ b/app/modals/options.html
@@ -247,6 +247,11 @@
                       <input type="checkbox" name="includeCurrentClassActions" ng-model="macroOptions.includeCurrentClassActions" ng-disabled="!macroOptions.setupCrossClassActions"/>
                       {{ 'MACRO_INCLUDE_CLASS' | translate }}
                     </label>
+                    <br/>
+                    <label class="checkbox" tooltip="{{ 'MACRO_LOCK_INFO' | translate }}" tooltip-placement="top">
+                      <input type="checkbox" name="includeMacroLock" ng-model="macroOptions.includeMacroLock"/>
+                      {{ 'MACRO_INCLUDE_LOCK' | translate }}
+                    </label>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This adds an option for including a `/macrolock` command at the start of each macro.

@Jengines, I've included French translations for the new text from Google Translate. Please let me know if there is a better translation.

Fixes #250.