### PR TITLE
Limit Muscle Memory and Piece by Piece

### DIFF
--- a/app/js/ffxivcraftmodel.js
+++ b/app/js/ffxivcraftmodel.js
@@ -451,12 +451,12 @@ function ApplyModifiers(s, action, condition) {
         bProgressGain = 40;
     }
     else if (isActionEq(action, AllActions.pieceByPiece)) {
-        bProgressGain = (s.synth.recipe.difficulty - s.progressState) * 0.33;
+        bProgressGain = Math.min((s.synth.recipe.difficulty - s.progressState) * 0.33, 1000);
     }
 
     if (isActionEq(action, AllActions.muscleMemory)) {
         if (s.step == 1) {
-            bProgressGain = (s.synth.recipe.difficulty - s.progressState) * 0.33;
+            bProgressGain = Math.min((s.synth.recipe.difficulty - s.progressState) * 0.33, 1000);
         }
         else {
             bProgressGain = 0;


### PR DESCRIPTION
Adds a 1000 maximum limit to the amount of progress gained by Piece by Piece and Muscle Memory, as added by Patch 5.0.