### PR TITLE
Update AngularJS CDN

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-busy/4.1.0/angular-busy.min.css"/>
   <link rel="stylesheet" href="css/base.css"/>
   <link rel="stylesheet" href="css/app.css"/>
-  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.32/angular.min.js"></script>
+  <script src="https://code.angularjs.org/1.2.32/angular.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/1.0.0-rc.1/angular-ui-router.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-busy/4.1.0/angular-busy.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-translate/2.6.1/angular-translate.min.js"></script>


### PR DESCRIPTION
Update angularjs cdn from googleapis.com to angularjs.org, in order to
support users in China.
Tested availability in Japan and USA as well, using VPN.
#319