### PR TITLE
Allow the CP modifier to be negative

### DIFF
--- a/app/components/simulator-status.html
+++ b/app/components/simulator-status.html
@@ -105,7 +105,7 @@
           <td class="col3 value">+&nbsp;{{buffStats.cp}}</td>
           <td class="col4">
             +&nbsp;
-            <input class="input-mini" type="number" min="0" required force-numeric ng-model="bonusStats.cp"/>
+            <input class="input-mini" type="number" required force-numeric ng-model="bonusStats.cp"/>
           </td>
           <td class="col5 value">=&nbsp;{{stats.cp}}</td>
           <td class="col6">&nbsp;</td>


### PR DESCRIPTION
If you want to run calculations to determine if you can use the 'Reuse' action, this is a hacky way to do it.  It won't account for things like modifiers that end on the final step, but it will be somewhat useful.
