### PR TITLE
Fix for issue #368 "Solver calculates Brand of the Elements progress …

### DIFF
--- a/app/js/ffxivcraftmodel.js
+++ b/app/js/ffxivcraftmodel.js
@@ -302,7 +302,7 @@ function ApplyModifiers(s, action, condition) {
 
     // Brand actions
     if (isActionEq(action, AllActions.brandOfTheElements)) {
-        var nameOfMultiplier = 1;
+        var nameOfMultiplier = 0;
         if (s.effects.countDowns.hasOwnProperty(AllActions.nameOfTheElements.shortName)) {
             nameOfMultiplier = Math.min(calcNameOfMultiplier(s), 2);
         }


### PR DESCRIPTION
…at 200% efficiency without Name of the Elements"

The issue is caused by initializing the variable "nameOfMultiplier" to 1 and adding it to "progressIncreaseMultiplier" even when NotE is not active. Multiple fixes available, this one simply initializes "nameOfMultiplier" to 0 (overridden anyway if NotE is active) and leaves the rest of the processing alone.